### PR TITLE
Requirement file for python 3.7 and updated missing dep for python 3.6. 

### DIFF
--- a/requirements-37.txt
+++ b/requirements-37.txt
@@ -13,4 +13,5 @@ PyOpenGL==3.1.5
 pyparsing==2.4.7
 python-dateutil==2.8.1
 scipy==1.5.4
+Shapely==1.7.1
 six==1.15.0


### PR DESCRIPTION
Note shapely is missing from python 3.6 and shall be added